### PR TITLE
feat: Dark Mode Experience Cards

### DIFF
--- a/components/experience-list/experience-item.tsx
+++ b/components/experience-list/experience-item.tsx
@@ -29,7 +29,7 @@ const ExperienceItem = ({ title, subTitle, description, startDate, endDate, inde
                     <div className={cn({
                         "rounded-l-md": isEven,
                         "rounded-r-md": isOdd,
-                    }, "shadow-md p-8 rounded-none sm:rounded-md z-10  relative bg-faded-cardboard text-magnetic-black")}>
+                    }, "shadow-md p-8 rounded-none sm:rounded-md z-10 relative bg-magnetic-black text-faded-cardboard")}>
                         <h3 className="font-bold tracking-wide">{title}</h3>
                         <div className="font-light">{subTitle}</div>
                         <p className="text-lg p-4 whitespace-pre-line">{description}</p>


### PR DESCRIPTION
## Overview\nThis PR switches the Experience section cards to a dark background with light text to match the rest of the site's retro mainframe aesthetic.\n\n### Changes\n- Swapped  for  in .\n- This makes the site consistent across desktop and mobile, avoiding the 'bright white' surprise on desktop and mirroring the 'auto dark mode' behavior seen on some mobile browsers.