### PR TITLE
feat: Spotify 'Now Playing' Integration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+SPOTIFY_CLIENT_ID="op://pi-cluster/mtgibbs-spotify/add more/client"
+SPOTIFY_CLIENT_SECRET="op://pi-cluster/mtgibbs-spotify/add more/client-secret"
+SPOTIFY_REFRESH_TOKEN="op://pi-cluster/mtgibbs-spotify/add more/refresh-token"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cn from 'classnames';
 
+import SpotifyCard from '../spotify/spotify-card';
 import VhsToggle from '../vhs-toggle/vhs-toggle';
 
 const Footer = (): React.ReactNode => {
@@ -9,6 +10,10 @@ const Footer = (): React.ReactNode => {
 
     return (
         <footer className="relative z-10 w-full bg-magnetic-black border-t border-signal-orange/30 py-8 px-4">
+            <div className="container mx-auto flex flex-col items-center gap-8 mb-8">
+                <SpotifyCard />
+            </div>
+
             <div className="container mx-auto flex flex-col lg:flex-row justify-between items-center gap-6">
                 <div className="text-faded-cardboard/40 font-mono text-[10px] tracking-[0.3em] uppercase order-2 lg:order-1">
                     © {new Date().getFullYear()} MTGIBBS.XYZ // ALL RIGHTS RESERVED

--- a/components/spotify/model/spotify-data.ts
+++ b/components/spotify/model/spotify-data.ts
@@ -1,0 +1,8 @@
+export interface SpotifyData {
+    isPlaying: boolean;
+    title?: string;
+    artist?: string;
+    album?: string;
+    albumImageUrl?: string;
+    songUrl?: string;
+}

--- a/components/spotify/spotify-card.tsx
+++ b/components/spotify/spotify-card.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import useSWR from 'swr';
+import cn from 'classnames';
+import { SpotifyData } from './model/spotify-data';
+
+const fetcher = (url: string) => fetch(url).then((r) => r.json());
+
+const SpotifyCard = () => {
+    const { data } = useSWR<SpotifyData>('/api/spotify', fetcher);
+
+    return (
+        <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={data?.isPlaying ? data.songUrl : 'https://open.spotify.com/user/mtgibbs'}
+            className={cn(
+                "relative flex items-center p-4 space-x-4 transition-shadow hover:shadow-lg border rounded-xl w-72 backdrop-blur-md bg-opacity-20",
+                data?.isPlaying
+                    ? "border-signal-orange bg-magnetic-black hover:border-chrome-blue"
+                    : "border-static-grey bg-magnetic-black opacity-80"
+            )}
+        >
+            <div className="flex-shrink-0 w-16 h-16 relative">
+                {data?.isPlaying ? (
+                    <img
+                        className="w-16 h-16 rounded-md shadow-sm animate-pulse-fast"
+                        src={data.albumImageUrl}
+                        alt={data.album}
+                    />
+                ) : (
+                    <div className="w-16 h-16 flex items-center justify-center bg-[#1DB954] rounded-md">
+                        <svg className="w-10 h-10 text-white" viewBox="0 0 168 168">
+                            <path fill="currentColor" d="M83.996.277C37.747.277.253 37.77.253 84.019c0 46.251 37.494 83.741 83.743 83.741 46.254 0 83.744-37.49 83.744-83.741 0-46.253-37.49-83.742-83.744-83.742zm38.404 120.78a5.217 5.217 0 01-7.18 1.73c-19.662-12.01-44.414-14.73-73.564-8.07a5.222 5.222 0 01-6.249-3.93 5.213 5.213 0 013.926-6.25c31.9-7.291 59.263-4.15 81.337 9.34 2.46 1.51 3.24 4.72 1.73 7.18zm10.25-22.805c-1.89 3.075-5.91 4.045-8.98 2.155-22.51-13.839-56.823-17.846-83.448-9.764-3.453 1.043-7.1-.903-8.148-4.35a6.538 6.538 0 014.354-8.143c30.413-9.228 68.222-4.758 94.072 11.127 3.07 1.89 4.04 5.91 2.15 8.976v-.001zm.88-23.744c-26.99-16.031-71.52-17.53-97.265-9.613-4.142 1.268-8.568-1.076-9.835-5.217-1.262-4.142 1.08-8.568 5.222-9.835 29.34-9.029 78.417-7.291 109.852 11.373 3.73 2.209 4.95 7.016 2.74 10.733-2.2 3.722-7.02 4.949-10.714 2.76z" />
+                        </svg>
+                    </div>
+                )}
+            </div>
+
+            <div className="flex flex-col min-w-0 flex-1">
+                {data?.isPlaying ? (
+                    <>
+                        <p className="font-bold text-sm text-faded-cardboard truncate font-sans">
+                            {data.title}
+                        </p>
+                        <p className="text-xs text-chrome-blue truncate font-sans">
+                            {data.artist}
+                        </p>
+                    </>
+                ) : (
+                    <div className="flex flex-col">
+                        <span className="font-bold text-sm text-faded-cardboard font-sans">Not Playing</span>
+                        <span className="text-xs text-static-grey font-sans">Spotify</span>
+                    </div>
+                )}
+            </div>
+
+            {data?.isPlaying && (
+                <div className="absolute top-2 right-2">
+                    <span className="relative flex h-3 w-3">
+                        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-signal-orange opacity-75"></span>
+                        <span className="relative inline-flex rounded-full h-3 w-3 bg-signal-orange"></span>
+                    </span>
+                </div>
+            )}
+        </a>
+    );
+};
+
+export default SpotifyCard;

--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -1,0 +1,34 @@
+
+const client_id = process.env.SPOTIFY_CLIENT_ID;
+const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
+const refresh_token = process.env.SPOTIFY_REFRESH_TOKEN;
+
+const basic = Buffer.from(`${client_id}:${client_secret}`).toString('base64');
+const TOKEN_ENDPOINT = `https://accounts.spotify.com/api/token`;
+const NOW_PLAYING_ENDPOINT = `https://api.spotify.com/v1/me/player/currently-playing`;
+
+const getAccessToken = async () => {
+    const response = await fetch(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: {
+            Authorization: `Basic ${basic}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refresh_token!,
+        }),
+    });
+
+    return response.json();
+};
+
+export const getNowPlaying = async () => {
+    const { access_token } = await getAccessToken();
+
+    return fetch(NOW_PLAYING_ENDPOINT, {
+        headers: {
+            Authorization: `Bearer ${access_token}`,
+        },
+    });
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -2,10 +2,14 @@
   "name": "mtgibbs.xyz",
   "version": "5.1.3",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "op run --env-file='./.env.template' -- next dev",
     "build": "next build",
     "start": "next start",
+    "start:local": "op run --env-file='./.env.template' -- next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.1.3",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "op run --env-file='./.env.template' -- next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/pages/api/spotify.ts
+++ b/pages/api/spotify.ts
@@ -1,0 +1,38 @@
+
+import { getNowPlaying } from '../../lib/spotify';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const response = await getNowPlaying();
+
+    if (response.status === 204 || response.status > 400) {
+        return res.status(200).json({ isPlaying: false });
+    }
+
+    const song = await response.json();
+
+    if (song.item === null) {
+        return res.status(200).json({ isPlaying: false });
+    }
+
+    const isPlaying = song.is_playing;
+    const title = song.item.name;
+    const artist = song.item.artists.map((_artist: any) => _artist.name).join(', ');
+    const album = song.item.album.name;
+    const albumImageUrl = song.item.album.images[0].url;
+    const songUrl = song.item.external_urls.spotify;
+
+    res.setHeader(
+        'Cache-Control',
+        'public, s-maxage=60, stale-while-revalidate=30'
+    );
+
+    return res.status(200).json({
+        album,
+        albumImageUrl,
+        artist,
+        isPlaying,
+        songUrl,
+        title,
+    });
+}


### PR DESCRIPTION
This PR adds a Spotify 'Now Playing' card to the footer.

**Key Features:**
- **Secure Dev Flow**: Uses 'op run' to inject Spotify secrets directly from 1Password into the dev process memory, ensuring no secrets are stored on disk in '.env.local'.
- **Components**: Added 'SpotifyCard' which polls '/api/spotify' to show real-time playback status.
- **Backend**: Added 'lib/spotify.ts' and 'pages/api/spotify.ts' to handle OAuth refresh flow and data fetching.
