### PR TITLE
Fix iOS transparency issue in experience cards and spotify component

### DIFF
--- a/components/experience-list/experience-item.tsx
+++ b/components/experience-list/experience-item.tsx
@@ -29,7 +29,7 @@ const ExperienceItem = ({ title, subTitle, description, startDate, endDate, inde
                     <div className={cn({
                         "rounded-l-md": isEven,
                         "rounded-r-md": isOdd,
-                    }, "shadow-md p-8 rounded-none sm:rounded-md z-10 relative bg-magnetic-black text-faded-cardboard")}>
+                    }, "shadow-md p-8 rounded-none sm:rounded-md z-10 relative bg-magnetic-black bg-opacity-100 text-faded-cardboard")}>
                         <h3 className="font-bold tracking-wide">{title}</h3>
                         <div className="font-light">{subTitle}</div>
                         <p className="text-lg p-4 whitespace-pre-line">{description}</p>

--- a/components/section-title/section-title.tsx
+++ b/components/section-title/section-title.tsx
@@ -12,6 +12,7 @@ const SectionTitle = ({ title }: SectionTitleProps): React.ReactNode => {
         <h1 className="text-lg 
             font-bold
             bg-magnetic-black
+            bg-opacity-100
             text-phosphor-amber
             border-y-2
             sm:border-2

--- a/components/spotify/spotify-card.tsx
+++ b/components/spotify/spotify-card.tsx
@@ -14,10 +14,10 @@ const SpotifyCard = () => {
             rel="noopener noreferrer"
             href={data?.isPlaying ? data.songUrl : 'https://open.spotify.com/user/mtgibbs'}
             className={cn(
-                "relative flex items-center p-4 space-x-4 transition-shadow hover:shadow-lg border rounded-xl w-72 backdrop-blur-md bg-opacity-20",
+                "relative flex items-center p-4 space-x-4 transition-shadow hover:shadow-lg border rounded-xl w-72 backdrop-blur-md",
                 data?.isPlaying
-                    ? "border-signal-orange bg-magnetic-black hover:border-chrome-blue"
-                    : "border-static-grey bg-magnetic-black opacity-80"
+                    ? "border-signal-orange bg-magnetic-black/20 hover:border-chrome-blue"
+                    : "border-static-grey bg-magnetic-black/20 opacity-80"
             )}
         >
             <div className="flex-shrink-0 w-16 h-16 relative">


### PR DESCRIPTION
## Description
This PR addresses a bug where elements like the Experience Cards appeared transparent or shadowed on iOS (Firefox/Safari). The issue was traced to the `SpotifyCard` component using the `bg-opacity-20` utility, which sets a CSS variable that was accidentally leaking into other contexts like the Experience items on some WebKit browsers.

## Changes
- **Experience Items**: Explicitly added `bg-opacity-100` to force full opacity on the cards, ensuring they render solidly over backgrounds.
- **Spotify Card**: Refactored to use the explicit alpha modifier syntax (`bg-magnetic-black/20`) instead of the composable `bg-opacity-20` utility. This prevents global variable pollution.
- **Section Titles**: Added `bg-opacity-100` as a defensive measure to ensure titles remain solid.

## Verification
- Verified that `ExperienceItem` cards now have a solid background.
- Validated that the Spotify card still retains its intended transparency but without side effects.
