### PR TITLE
feat(a11y): Semantic Navigation and Focus Management

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,15 @@ const Home: NextPage = () => {
         <link rel="apple-touch-icon" href="/apple-touch-icon.png"></link>
       </Head>
 
-      <main className={cn(styles.main, "w-full relative bg-magnetic-black overflow-x-hidden")}>
+      {/* Skip to Content Link for Keyboard Accessibility */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-signal-orange focus:text-white focus:outline-none focus:ring-2 focus:ring-white font-mono font-bold"
+      >
+        SKIP TO CONTENT
+      </a>
+
+      <main id="main-content" className={cn(styles.main, "w-full relative bg-magnetic-black overflow-x-hidden")}>
         <CyberGrid />
 
         <section className="relative z-10 w-full h-full px-0 py-12 sm:py-16 md:py-20 bg-transparent text-faded-cardboard">
@@ -95,8 +103,9 @@ const Home: NextPage = () => {
           <DevIconList icons={ICON_OPTIONS}></DevIconList>
         </section>
 
-        <Footer />
       </main>
+
+      <Footer />
 
       {/* <footer className={styles.footer}>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,12 @@ body {
   --tracking-red: #D93636;
 }
 
+/* Accessibility: Global visible focus ring */
+*:focus-visible {
+  outline: 2px solid var(--signal-orange);
+  outline-offset: 2px;
+}
+
 /* Cyberpunk Utilities */
 .clip-corner {
   clip-path: polygon(0 0,


### PR DESCRIPTION
## Accessibility Step 2: Navigation & Keyboarding

This PR improves the experience for keyboard-only users and screen readers.

### Key Changes
*   **Skip to Content**: Added a hidden link at the top of the page that becomes visible on focus, allowing users to bypass the hero section and jump straight to the main content.
*   **Semantic Structure**: Verified and updated page structure. Moved `<Footer>` outside of `<main>` to adhere to correct HTML5 semantic landmarks.
*   **Visible Focus Ring**: Replaced default browser outlines with a themed **Signal Orange** focus ring (via `:focus-visible`). This ensures focus state is clearly visible while matching the site's aesthetic.
*   **Main Content ID**: Added `id='main-content'` to the main wrapper to support the skip link.