### PR TITLE
feat(a11y): High Contrast & Dynamic Updates

### DIFF
--- a/components/spotify/spotify-card.tsx
+++ b/components/spotify/spotify-card.tsx
@@ -71,6 +71,10 @@ const SpotifyCard = () => {
                     </span>
                 </div>
             )}
+            {/* Live Region for Screen Reader Announcements */}
+            <div className="sr-only" aria-live="polite" aria-atomic="true">
+                {data?.isPlaying ? `Now playing: ${data.title} by ${data.artist}` : 'Spotify is currently offline'}
+            </div>
         </a>
     );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,19 @@ body {
   --tracking-red: #D93636;
 }
 
+/* Accessibility: High Contrast Mode Overrides */
+@media (prefers-contrast: more) {
+  :root {
+    --magnetic-black: #000000;
+    --faded-cardboard: #FFFFFF;
+    --chrome-blue: #80BFFF;
+    --tracking-red: #FF6666;
+    --signal-orange: #FF5500;
+    --phosphor-amber: #FFD500;
+    --static-grey: #404040;
+  }
+}
+
 /* Accessibility: Global visible focus ring */
 *:focus-visible {
   outline: 2px solid var(--signal-orange);


### PR DESCRIPTION
## Accessibility Step 4: The Final Polish

This PR targets the remaining WCAG criteria regarding contrast and dynamic content.

### Key Changes
*   **High Contrast Mode**:
    *   Detected via `prefers-contrast: more`.
    *   Overrides the 'Cyber' color palette with high-visibility equivalents.
    *   **Magnetic Black** becomes **Pure Black**.
    *   **Chrome Blue** (#3B5C7D) -> **#80BFFF** (Clear Sky Blue).
    *   **Tracking Red** (#D93636) -> **#FF6666** (Bright Red).
    *   This ensures users with low vision get a clearer, sharper experience.
*   **Dynamic Announcements**:
    *   Added an invisible `aria-live='polite'` region to the Spotify component.
    *   When the song changes, Screen Readers will now announce: *'Now playing: [Song] by [Artist]'*.
    *   This closes the gap on dynamic content not being perceived by non-visual users.