### PR TITLE
feat(easter-egg): Konami Code High Contrast Toggle

### DIFF
--- a/hooks/use-konami.ts
+++ b/hooks/use-konami.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+const KONAMI_CODE = [
+    'ArrowUp',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'ArrowLeft',
+    'ArrowRight',
+    'b',
+    'a',
+];
+
+export const useKonami = (action: () => void) => {
+    const [input, setInput] = useState<string[]>([]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const newItem = e.key;
+
+            setInput((prev) => {
+                const newInput = [...prev, newItem];
+
+                // Keep only as many keystrokes as the code length
+                if (newInput.length > KONAMI_CODE.length) {
+                    newInput.shift();
+                }
+
+                // Check for match
+                if (JSON.stringify(newInput) === JSON.stringify(KONAMI_CODE)) {
+                    action();
+                    return []; // Reset after success
+                }
+
+                return newInput;
+            });
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [action]);
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,8 +2,15 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import { VhsProvider } from '../context/VhsContext'
 import { GPUProvider } from '../context/GPUContext'
+import { useKonami } from '../hooks/use-konami'
 
 function MyApp({ Component, pageProps }: AppProps) {
+  useKonami(() => {
+    document.body.classList.toggle('high-contrast');
+    // Easter egg feedback
+    console.log('ACCESS GRANTED: High Contrast Protocol Engaged');
+  });
+
   return (
     <GPUProvider>
       <VhsProvider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,30 @@ body {
   --tracking-red: #D93636;
 }
 
+/* Accessibility: High Contrast Mode Overrides */
+/* Applied via OS setting OR 'high-contrast' body class */
+@media (prefers-contrast: more) {
+  :root {
+    --magnetic-black: #000000;
+    --faded-cardboard: #FFFFFF;
+    --chrome-blue: #80BFFF;
+    --tracking-red: #FF6666;
+    --signal-orange: #FF5500;
+    --phosphor-amber: #FFD500;
+    --static-grey: #404040;
+  }
+}
+
+body.high-contrast {
+  --magnetic-black: #000000;
+  --faded-cardboard: #FFFFFF;
+  --chrome-blue: #80BFFF;
+  --tracking-red: #FF6666;
+  --signal-orange: #FF5500;
+  --phosphor-amber: #FFD500;
+  --static-grey: #404040;
+}
+
 /* Accessibility: Global visible focus ring */
 *:focus-visible {
   outline: 2px solid var(--signal-orange);


### PR DESCRIPTION
## Easter Egg: Konami Code Accessibility

This PR adds a manual trigger for High Contrast Mode using the classic Konami Code.

### How to use
1.  Focus on the page.
2.  Enter: **Up, Up, Down, Down, Left, Right, Left, Right, B, A**.
3.  The site will instantly toggle High Contrast Mode.

### Implementation
*   **useKonami Hook**: A reusable hook that listens for the key sequence.
*   **CSS Update**: Refactored the High Contrast logic to support both the OS `prefers-contrast` setting AND the manual `.high-contrast` body class.
*   **Safety**: This overrides any existing theme settings to ensure readability.