### PR TITLE
fix: Uppercase and Deduplicate Tech Stack

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -60,9 +60,9 @@ export async function getPinnedProjects(): Promise<IProject[]> {
     const pinnedNodes = json.data?.user?.pinnedItems?.nodes || [];
 
     return pinnedNodes.map((repo: any) => {
-      const languages = repo.languages?.nodes?.map((l: any) => l.name) || [];
-      const topics = repo.repositoryTopics?.nodes?.map((t: any) => t.topic.name) || [];
-      // Deduplicate and combine
+      const languages = repo.languages?.nodes?.map((l: any) => l.name.toUpperCase()) || [];
+      const topics = repo.repositoryTopics?.nodes?.map((t: any) => t.topic.name.toUpperCase()) || [];
+      // Deduplicate and combine (case-insensitivity handled by uppercasing first)
       const techStack = Array.from(new Set([...languages, ...topics]));
 
       return {


### PR DESCRIPTION
Normalizes all project tech stack tags (languages and topics) to uppercase to enforce the terminal aesthetic and prevent duplicate entries due to case sensitivity (e.g. TypeScript vs typescript).