### PR TITLE
fix(docker): Secure Build Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,10 @@ jobs:
           # Login to Heroku Container Registry
           echo $HEROKU_API_KEY | docker login --username=_ --password-stdin registry.heroku.com
           
-          # Build Image (Heroku only needs amd64 usually, so we stick to simple build here)
-          docker build --build-arg NEXT_PUBLIC_VERSION=$APP_VERSION --build-arg GITHUB_ACCESS_TOKEN=${{ secrets.GH_ACCESS_TOKEN }} -t registry.heroku.com/$HEROKU_APP_NAME/web .
+          # Build Image
+          echo "${{ secrets.GH_ACCESS_TOKEN }}" > secret_token.txt
+          docker build --build-arg NEXT_PUBLIC_VERSION=$APP_VERSION --secret id=GITHUB_ACCESS_TOKEN,src=secret_token.txt -t registry.heroku.com/$HEROKU_APP_NAME/web .
+          rm secret_token.txt
           
           # Push Image
           docker push registry.heroku.com/$HEROKU_APP_NAME/web
@@ -103,6 +105,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_VERSION=${{ needs.prepare.outputs.version }}
+          secrets: |
             GITHUB_ACCESS_TOKEN=${{ secrets.GH_ACCESS_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,9 @@ COPY . .
 ARG NEXT_PUBLIC_VERSION=local
 ENV NEXT_PUBLIC_VERSION=$NEXT_PUBLIC_VERSION
 
-ARG GITHUB_ACCESS_TOKEN
-ENV GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN
-
-RUN npm run build
+RUN --mount=type=secret,id=GITHUB_ACCESS_TOKEN \
+    GITHUB_ACCESS_TOKEN=$(cat /run/secrets/GITHUB_ACCESS_TOKEN) \
+    npm run build
 
 # If using npm comment out above and use below instead
 # RUN npm run build


### PR DESCRIPTION
Resolves Docker build warnings by migrating from 'ARG/ENV' to BuildKit secrets usage for 'GITHUB_ACCESS_TOKEN'.

- **Dockerfile:** Replaces insecure `ARG/ENV` pattern with `RUN --mount=type=secret`.
- **CI/CD:** Updates GitHub Actions (`deploy.yml`) to pass secrets securely via `--secret` flag for Heroku and `secrets` block for GHCR.