### PR TITLE
fix: Enable Self-Hosted Analytics Proxy & Local Dev Key

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,5 +4,5 @@ SPOTIFY_REFRESH_TOKEN="op://pi-cluster/mtgibbs-spotify/add more/refresh-token"
 GITHUB_ACCESS_TOKEN="op://pi-cluster/mtgibbs-github/token"
 
 # Optional: Umami Analytics
-NEXT_PUBLIC_UMAMI_WEBSITE_ID="op://pi-cluster/mtgibbs-analytics/website-id"
+NEXT_PUBLIC_UMAMI_WEBSITE_ID="op://pi-cluster/mtgibbs-tracking/LOCAL_DEV_WEBSITE_ID"
 UMAMI_HOST_URL="https://mtgibbs-tracking.herokuapp.com"

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
+  async rewrites() {
+    return [
+      {
+        source: '/api/analytics/:path*',
+        destination: `${process.env.UMAMI_HOST_URL || 'https://mtgibbs-tracking.herokuapp.com'}/:path*`,
+      },
+    ]
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Changes
- **next.config.js**: Added async rewrites to proxy `/api/analytics/*` to the self-hosted Umami instance (`UMAMI_HOST_URL`). This resolver enables the tracking script to load without being blocked by privacy extensions.
- **.env.template**: Updated to support `LOCAL_DEV_WEBSITE_ID` from the 1Password vault, allowing safe local testing without polluting production data.

## Verification
- Confirmed `/api/analytics/script.js` loads with 200 OK.
- Confirmed tracking requests to `/api/analytics/api/send` succeed (200 OK) when using the valid local key.