### PR TITLE
Debug Umami Tracking and Fix Proxy Config

### DIFF
--- a/components/analytics/UmamiScript.tsx
+++ b/components/analytics/UmamiScript.tsx
@@ -4,8 +4,11 @@ const UmamiScript = () => {
     const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
 
     if (!websiteId) {
+        console.warn('Umami Tracking: No NEXT_PUBLIC_UMAMI_WEBSITE_ID found. Tracking disabled.');
         return null;
     }
+
+    console.log('Umami Tracking: Initialized with ID:', websiteId);
 
     return (
         <Script

--- a/next.config.js
+++ b/next.config.js
@@ -4,10 +4,10 @@ const nextConfig = {
   output: 'standalone',
   async rewrites() {
     return [
-      {
-        source: '/api/analytics/:path*',
-        destination: `${process.env.UMAMI_HOST_URL || 'https://mtgibbs-tracking.herokuapp.com'}/:path*`,
-      },
+      // {
+      //   source: '/api/analytics/:path*',
+      //   destination: `${process.env.UMAMI_HOST_URL || 'https://mtgibbs-tracking.herokuapp.com'}/:path*`,
+      // },
     ]
   },
 }

--- a/pages/api/analytics/[...path].ts
+++ b/pages/api/analytics/[...path].ts
@@ -2,16 +2,16 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     const { path } = req.query;
-    const hostUrl = process.env.UMAMI_HOST_URL;
+    const hostUrl = process.env.UMAMI_HOST_URL || 'https://mtgibbs-tracking.herokuapp.com';
 
-    // 1. Silent Exit if not configured
-    if (!hostUrl) {
-        return res.status(200).end();
-    }
+    console.log(`[Umami Proxy] Request for: ${path}`);
+    console.log(`[Umami Proxy] Upstream Host: ${hostUrl}`);
 
     // Reconstruct the path (e.g., ["script.js"] -> "/script.js")
     const pathStr = Array.isArray(path) ? path.join('/') : path;
     const targetUrl = `${hostUrl.replace(/\/$/, '')}/${pathStr}`;
+
+    console.log(`[Umami Proxy] Proxying to: ${targetUrl}`);
 
     try {
         // 2. Prepare headers


### PR DESCRIPTION
This PR adds logging to the analytics API route and disables the next.config.js rewrite to ensure the fallback URL logic works correctly in production. This is to diagnose why tracking is failing on Heroku.