### PR TITLE
Switch to Runtime Analytics Configuration

### DIFF
--- a/components/analytics/UmamiScript.tsx
+++ b/components/analytics/UmamiScript.tsx
@@ -1,14 +1,33 @@
+import React, { useEffect, useState } from 'react';
 import Script from 'next/script';
 
 const UmamiScript = () => {
-    const websiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+    const [websiteId, setWebsiteId] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchConfig = async () => {
+            try {
+                const res = await fetch('/api/config');
+                if (res.ok) {
+                    const data = await res.json();
+                    if (data.umamiWebsiteId) {
+                        console.log('Umami Tracking: Runtime ID loaded:', data.umamiWebsiteId);
+                        setWebsiteId(data.umamiWebsiteId);
+                    } else {
+                        console.warn('Umami Tracking: No ID returned from /api/config');
+                    }
+                }
+            } catch (error) {
+                console.error('Umami Tracking: Failed to fetch config', error);
+            }
+        };
+
+        fetchConfig();
+    }, []);
 
     if (!websiteId) {
-        console.warn('Umami Tracking: No NEXT_PUBLIC_UMAMI_WEBSITE_ID found. Tracking disabled.');
         return null;
     }
-
-    console.log('Umami Tracking: Initialized with ID:', websiteId);
 
     return (
         <Script

--- a/pages/api/config.ts
+++ b/pages/api/config.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+    res.status(200).json({
+        umamiWebsiteId: process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID || process.env.UMAMI_WEBSITE_ID,
+    });
+}


### PR DESCRIPTION
This PR refactors Umami tracking to fetch the Website ID at runtime via a new API endpoint (/api/config). This allows the same Docker image to be used across different environments (e.g., Heroku vs Pi Cluster) with different tracking IDs, properly respecting the runtime environment variables.