### PR TITLE
feat(analytics): add heartbeat to track session duration

### DIFF
--- a/components/analytics/UmamiScript.tsx
+++ b/components/analytics/UmamiScript.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import Script from 'next/script';
 
+declare global {
+    interface Window {
+        umami?: {
+            track: (eventName: string, data?: Record<string, any>) => void;
+        };
+    }
+}
+
 const UmamiScript = () => {
     const [websiteId, setWebsiteId] = useState<string | null>(null);
 
@@ -24,6 +32,18 @@ const UmamiScript = () => {
 
         fetchConfig();
     }, []);
+
+    useEffect(() => {
+        if (!websiteId) return;
+
+        const heartbeat = setInterval(() => {
+            if (document.visibilityState === 'visible' && window.umami) {
+                window.umami.track('heartbeat');
+            }
+        }, 30000);
+
+        return () => clearInterval(heartbeat);
+    }, [websiteId]);
 
     if (!websiteId) {
         return null;


### PR DESCRIPTION
This PR adds a heartbeat mechanism to the Umami tracking script. It sends a 'heartbeat' event every 30 seconds while the page is visible to better track user session duration.